### PR TITLE
add latest goodness from archetype ci config

### DIFF
--- a/.circleci/.maven.xml
+++ b/.circleci/.maven.xml
@@ -1,0 +1,27 @@
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/SETTINGS/1.0.0" xsi:schemalocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <!-- Maven Central Deployment -->
+      <id>rso</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>gpg</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+        <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>gpg</activeProfile>
+  </activeProfiles>
+</settings>

--- a/.circleci/circleci-readme.md
+++ b/.circleci/circleci-readme.md
@@ -13,4 +13,12 @@ The local build runs in a docker container.
           
         circleci local execute -c .circleci/local-config.yml --job 'github-maven-deploy/build-and-test'
 
-    With the above command, those operations what cannot occur locally will show an error (like `Error: FAILED with error not supported`), but the build will proceed and can complete “successfully”, which allows you to verify scripts in your config, etc.
+    With the above command, operations that cannot occur during a local build will show an error like this:
+     
+      ```
+      ... Error: FAILED with error not supported
+      ```
+    
+      However, the build will proceed and can complete “successfully”, which allows you to verify scripts in your config, etc.
+      
+      If the build does complete successfully, you should see a happy yellow `Success!` message.

--- a/.circleci/circleci-readme.md
+++ b/.circleci/circleci-readme.md
@@ -1,0 +1,16 @@
+CI Debug Notes
+================
+To validate some circleci stuff, I was able to run a “build locally” using the steps below.
+The local build runs in a docker container.
+
+  * (Once) Install circleci client (`brew install circleci`)
+
+  * Convert the “real” config.yml into a self contained (non-workspace) config via:
+
+        circleci config process .circleci/config.yml > .circleci/local-config.yml
+
+  * Run a local build with the following command:
+          
+        circleci local execute -c .circleci/local-config.yml --job 'github-maven-deploy/build-and-test'
+
+    With the above command, those operations what cannot occur locally will show an error (like `Error: FAILED with error not supported`), but the build will proceed and can complete “successfully”, which allows you to verify scripts in your config, etc.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,17 @@ orbs:
   github-maven-deploy: github-maven-deploy/github-maven-deploy@1.0.5
 
 mvn-build-test-command: &mvn-build-test-command
-  mvn-build-test-command: mvn clean package -PbuildKar
+  mvn-build-test-command: mvn clean verify -PbuildKar -Dit
 
+mvn-deploy-command: &mvn-deploy-command
+  mvn-deploy-command: mvn -s .circleci/.maven.xml clean deploy -PbuildKar -DdeployAtEnd=true -DperformRelease=true -DskipTests -Dspotbugs.skip=true
+  context: rso-base
 
 mvn-collect-artifacts-command: &mvn-collect-artifacts-command
   mvn-collect-artifacts-command: |
     mkdir -p ~/project/artifacts/junit/
-    cp ~/project/target/surefire-reports/*.xml ~/project/artifacts/junit/
-    cp ~/project/target/nexus-repository-* ~/project/artifacts/
-
-mvn-deploy-command: &mvn-deploy-command
-  mvn-deploy-command: mvn -s .maven.xml clean deploy -PbuildKar -DdeployAtEnd=true -DperformRelease=true -DskipTests -Dspotbugs.skip=true
-  context: rso-dantest
+    find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/project/artifacts/junit/ \;
+    cp ~/project/nexus-repository-apk-it/target/failsafe-reports/*.xml ~/project/artifacts/junit/
 
 workflows:
   workflow:
@@ -28,23 +27,41 @@ workflows:
           type: approval
           requires:
             - github-maven-deploy/build-and-test
+          filters:
+            branches:
+              only: master
       - github-maven-deploy/approve-deploy-minor-version:
           type: approval
           requires:
             - github-maven-deploy/build-and-test
+          filters:
+            branches:
+              only: master
       - github-maven-deploy/approve-deploy-major-version:
           type: approval
           requires:
             - github-maven-deploy/build-and-test
+          filters:
+            branches:
+              only: master
       - github-maven-deploy/deploy-patch-version:
           requires:
             - github-maven-deploy/approve-deploy-patch-version
           <<: *mvn-deploy-command
+          filters:
+            branches:
+              only: master
       - github-maven-deploy/deploy-minor-version:
           requires:
             - github-maven-deploy/approve-deploy-minor-version
           <<: *mvn-deploy-command
+          filters:
+            branches:
+              only: master
       - github-maven-deploy/deploy-major-version:
           requires:
             - github-maven-deploy/approve-deploy-major-version
           <<: *mvn-deploy-command
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
CI was failing due to old config copy/pasta. Latest chewy goodness from the [archetype source of truth](https://github.com/sonatype-nexus-community/nexus-format-archetype/tree/master/src/main/resources/archetype-resources/.circleci) copied over.

For yucks and giggles, @allenhsieh could you try out the steps in the ci readme, and let me know how it goes for you? Thanks!

cc @DarthHater @bhamail
