### PR TITLE
APK module version out of sync in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN cd /nexus-repository-apk/; \
 
 FROM sonatype/nexus3:$NEXUS_VERSION
 
-ARG FORMAT_VERSION=0.0.1
+ARG FORMAT_VERSION=0.0.5-SNAPSHOT
 ARG DEPLOY_DIR=/opt/sonatype/nexus/deploy/
 USER root
 COPY --from=build /nexus-repository-apk/nexus-repository-apk/target/nexus-repository-apk-${FORMAT_VERSION}-bundle.kar ${DEPLOY_DIR}


### PR DESCRIPTION
Docker builds no longer work due to change in apk module version numbering.

This pull request makes the following changes:
* Update Dockerfile variable
cc @DarthHater @bhamail
