### PR TITLE
Bump maven-release-orb to version 0.0.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   github-maven-deploy: github-maven-deploy/github-maven-deploy@1.0.5
-  circleci-maven-release-orb: sonatype-nexus-community/circleci-maven-release-orb@0.0.11
+  circleci-maven-release-orb: sonatype-nexus-community/circleci-maven-release-orb@0.0.15
 
 workflows:
   build-and-test:


### PR DESCRIPTION
Per @bhamail, bumping maven-release-orb to version 0.0.15

This pull request makes the following changes:
* bumping maven-release-orb to version 0.0.15