### PR TITLE
Add a download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@
 
 Also, there is a good amount of information available at [Bundle Development](https://help.sonatype.com/display/NXRM3/Bundle+Development)
 
+### Download
+
+Find the pre-compiled file from [here](https://search.maven.org/search?q=g:%22org.sonatype.nexus.plugins%22%20AND%20a:%22nexus-repository-apk%22).
+
 ### Building
 
 To build the project and generate the bundle use Maven


### PR DESCRIPTION
A small fix of the readme file

This pull request makes the following changes:
* Add a download link of current plugin

It relates to the following issue #s:
* Fixes #20 

cc @DarthHater @bhamail
