### PR TITLE
align code with nxrm 3.26.0

### DIFF
--- a/nexus-repository-apk-it/src/test/java/org/sonatype/nexus/plugins/apk/internal/ApkITSupport.java
+++ b/nexus-repository-apk-it/src/test/java/org/sonatype/nexus/plugins/apk/internal/ApkITSupport.java
@@ -19,11 +19,16 @@ import javax.annotation.Nonnull;
 import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.plugins.apk.internal.fixtures.RepositoryRuleApk;
 import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.repository.storage.StorageTx;
 import org.sonatype.nexus.testsuite.testsupport.RepositoryITSupport;
 
 import org.junit.Rule;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter.P_NAME;
 
 public class ApkITSupport
     extends RepositoryITSupport
@@ -52,5 +57,23 @@ public class ApkITSupport
         clientContext(),
         repositoryUrl.toURI()
     );
+  }
+
+  protected static Asset findAsset(final Repository repo, final String name) {
+    try (StorageTx tx = getStorageTx(repo)) {
+      tx.begin();
+      return tx.findAssetWithProperty(P_NAME, name, tx.findBucket(repo));
+    }
+  }
+
+  protected static Component findComponent(final Repository repo, final String name) {
+    try (StorageTx tx = getStorageTx(repo)) {
+      tx.begin();
+      return tx.findComponentWithProperty(P_NAME, name, tx.findBucket(repo));
+    }
+  }
+
+  protected static StorageTx getStorageTx(final Repository repository) {
+    return repository.facet(StorageFacet.class).txSupplier().get();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.23.0-03</version>
+    <version>3.26.0-01</version>
   </parent>
 
   <artifactId>apk-parent</artifactId>
@@ -42,7 +42,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.23.0-03</nxrm-version>
+    <nxrm-version>3.26.0-01</nxrm-version>
   </properties>
 
 


### PR DESCRIPTION
In the Nexus Repository Manager  3.26.0 were made a couple of API changes that should be applied in APK plugin as well.

3.26.0-01 is currently not released, so. Tests will be passed once 3.26.0 will be public.