### PR TITLE
Build against latest nexus repository manager release: 3.28.0-01

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   circleci-maven-release-orb: sonatype-nexus-community/circleci-maven-release-orb@0.0.15
 
 build-and-test-commands: &build-and-test-commands
-  mvn-build-test-command: mvn clean verify -PbuildKar -Dit
+  mvn-build-test-command: mvn clean --batch-mode verify -PbuildKar -Dit
   mvn-collect-artifacts-command: |
     mkdir -p ~/project/artifacts/junit/
     find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/project/artifacts/junit/ \;

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The table below outlines what version of Nexus Repository the plugin was built a
 |----------------|--------------------------|
 | v0.0.1         | 3.19.0-01                |
 | v0.0.8         | 3.23.0-03                |
+| v0.0.12        | 3.28.0-01                |
 
 If a new version of Nexus Repository is released and the plugin needs changes, a new release will be made, and this
 table will be updated to indicate which version of Nexus Repository it will function against. This is done on a time 

--- a/nexus-repository-apk-it/pom.xml
+++ b/nexus-repository-apk-it/pom.xml
@@ -72,11 +72,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.sonatype.nexus</groupId>
-      <artifactId>nexus-testsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/nexus-repository-apk-it/pom.xml
+++ b/nexus-repository-apk-it/pom.xml
@@ -72,6 +72,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-testsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/nexus-repository-apk/pom.xml
+++ b/nexus-repository-apk/pom.xml
@@ -27,11 +27,6 @@
       <artifactId>commons-compress</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.goodies</groupId>
-      <artifactId>goodies-testsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-rapture</artifactId>
       <scope>provided</scope>

--- a/nexus-repository-apk/pom.xml
+++ b/nexus-repository-apk/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>nexus-rapture</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-testsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkContentValidator.java
+++ b/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkContentValidator.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.plugins.apk.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -23,10 +24,8 @@ import javax.inject.Singleton;
 
 import org.sonatype.goodies.common.ComponentSupport;
 import org.sonatype.nexus.mime.MimeRulesSource;
-import org.sonatype.nexus.repository.storage.ContentValidator;
-import org.sonatype.nexus.repository.storage.DefaultContentValidator;
-
-import com.google.common.base.Supplier;
+import org.sonatype.nexus.repository.mime.ContentValidator;
+import org.sonatype.nexus.repository.mime.DefaultContentValidator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkDataAccess.java
+++ b/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkDataAccess.java
@@ -12,7 +12,6 @@
  */
 package org.sonatype.nexus.plugins.apk.internal;
 
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 
 import org.sonatype.nexus.blobstore.api.Blob;
@@ -30,6 +29,7 @@ import javax.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
 import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA1;

--- a/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkProxyFacetImpl.java
+++ b/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkProxyFacetImpl.java
@@ -27,7 +27,6 @@ import org.sonatype.nexus.repository.storage.Bucket;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.StorageFacet;
 import org.sonatype.nexus.repository.storage.StorageTx;
-import org.sonatype.nexus.repository.storage.TempBlob;
 import org.sonatype.nexus.repository.transaction.TransactionalStoreBlob;
 import org.sonatype.nexus.repository.transaction.TransactionalTouchBlob;
 import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
@@ -35,6 +34,7 @@ import org.sonatype.nexus.repository.view.Content;
 import org.sonatype.nexus.repository.view.Context;
 import org.sonatype.nexus.repository.view.Payload;
 import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
+import org.sonatype.nexus.repository.view.payloads.TempBlob;
 import org.sonatype.nexus.transaction.UnitOfWork;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.26.0-01</version>
+    <version>3.28.0-01</version>
   </parent>
 
   <artifactId>apk-parent</artifactId>
@@ -42,9 +42,8 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.26.0-01</nxrm-version>
+    <nxrm-version>3.28.0-01</nxrm-version>
   </properties>
-
 
   <repositories>
     <!-- ensure we can find the parent pom when starting from an empty local .m2 repository -->
@@ -113,7 +112,7 @@
       only sign during deploy phase
       -->
       <build>
-        <plugins>       
+        <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>


### PR DESCRIPTION
Plugin is incompatible with Nexus 3.28.0 :

-  ```org.sonatype.nexus.repository.storage.ContentValidator``` is deprecated. I switch to interface ```org.sonatype.nexus.repository.mime.ContentValidator```
- ```org.sonatype.nexus.repository.mime.ContentValidator``` now use jdk built-in Supplier class instead of guava one
- ```org.sonatype.nexus.repository.storage.TempBlob``` is deprecated too, use ```org.sonatype.nexus.repository.view.payloads.TempBlob``` instead
- Fix tests