### PR TITLE
Replace Supplier<InputStream> by InputStreamSupplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The table below outlines what version of Nexus Repository the plugin was built a
 | v0.0.8         | 3.23.0-03                |
 | v0.0.12        | 3.28.0-01                |
 | v0.0.18        | 3.30.0-01                |
+| v0.0.19        | 3.31.0-01                |
 
 If a new version of Nexus Repository is released and the plugin needs changes, a new release will be made, and this
 table will be updated to indicate which version of Nexus Repository it will function against. This is done on a time

--- a/nexus-repository-apk/pom.xml
+++ b/nexus-repository-apk/pom.xml
@@ -36,6 +36,15 @@
       <artifactId>nexus-testsupport</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- @todo remove explicit dependency on org.apache.geronimo.specs:geronimo-atinject_1.0_spec:jar:1.0
+    When testing removal of this dependency, be sure to delete geronimo-atinject_1.0_spec from you local .m2 cache
+    -->
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-atinject_1.0_spec</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkContentValidator.java
+++ b/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkContentValidator.java
@@ -12,20 +12,18 @@
  */
 package org.sonatype.nexus.plugins.apk.internal;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.function.Supplier;
+import org.sonatype.goodies.common.ComponentSupport;
+import org.sonatype.nexus.common.io.InputStreamSupplier;
+import org.sonatype.nexus.mime.MimeRulesSource;
+import org.sonatype.nexus.repository.mime.ContentValidator;
+import org.sonatype.nexus.repository.mime.DefaultContentValidator;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-
-import org.sonatype.goodies.common.ComponentSupport;
-import org.sonatype.nexus.mime.MimeRulesSource;
-import org.sonatype.nexus.repository.mime.ContentValidator;
-import org.sonatype.nexus.repository.mime.DefaultContentValidator;
+import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -45,7 +43,7 @@ public class ApkContentValidator
   @Nonnull
   @Override
   public String determineContentType(final boolean strictContentTypeValidation,
-                                     final Supplier<InputStream> contentSupplier,
+                                     final InputStreamSupplier contentSupplier,
                                      @Nullable final MimeRulesSource mimeRulesSource,
                                      @Nullable final String contentName,
                                      @Nullable final String declaredContentType) throws IOException

--- a/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkDataAccess.java
+++ b/nexus-repository-apk/src/main/java/org/sonatype/nexus/plugins/apk/internal/ApkDataAccess.java
@@ -13,10 +13,10 @@
 package org.sonatype.nexus.plugins.apk.internal;
 
 import com.google.common.collect.ImmutableList;
-
 import org.sonatype.nexus.blobstore.api.Blob;
 import org.sonatype.nexus.common.collect.AttributesMap;
 import org.sonatype.nexus.common.hash.HashAlgorithm;
+import org.sonatype.nexus.common.io.InputStreamSupplier;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.storage.*;
 import org.sonatype.nexus.repository.view.Content;
@@ -25,11 +25,8 @@ import org.sonatype.nexus.repository.view.payloads.BlobPayload;
 
 import javax.annotation.Nullable;
 import javax.inject.Named;
-
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
-import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
 import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA1;
@@ -85,7 +82,7 @@ public class ApkDataAccess
    */
   public Content saveAsset(final StorageTx tx,
                            final Asset asset,
-                           final Supplier<InputStream> contentSupplier,
+                           final InputStreamSupplier contentSupplier,
                            final Payload payload) throws IOException
   {
     AttributesMap contentAttributes = null;
@@ -104,7 +101,7 @@ public class ApkDataAccess
    */
   public Content saveAsset(final StorageTx tx,
                            final Asset asset,
-                           final Supplier<InputStream> contentSupplier,
+                           final InputStreamSupplier contentSupplier,
                            final String contentType,
                            @Nullable final AttributesMap contentAttributes) throws IOException
   {

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.30.0-01</version>
+    <version>3.31.0-01</version>
   </parent>
 
   <artifactId>apk-parent</artifactId>
@@ -42,7 +42,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.30.0-01</nxrm-version>
+    <nxrm-version>3.31.0-01</nxrm-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
When using Nexus 3.31, I have this error when trying to use my APK repository :

```
2021-06-21 09:18:43,929+0200 ERROR [qtp607840616-6744]  *SYSTEM org.sonatype.nexus.internal.web.ErrorPageServlet - Unexpected exception
java.lang.NoSuchMethodError: org.sonatype.nexus.repository.storage.StorageTx.setBlob(Lorg/sonatype/nexus/repository/storage/Asset;Ljava/lang/String;Ljava/util/function/Supplier;Ljava/lang/Iterable;Ljava/util/Map;Ljava/lang/String;Z)Lorg/sonatype/nexus/repository/storage/AssetBlob;
	at org.sonatype.nexus.plugins.apk.internal.ApkDataAccess.saveAsset(ApkDataAccess.java:112)
	at org.sonatype.nexus.plugins.apk.internal.ApkDataAccess.saveAsset(ApkDataAccess.java:97)
	at org.sonatype.nexus.plugins.apk.internal.ApkProxyFacetImpl.doPutIndex(ApkProxyFacetImpl.java:161)
	at org.sonatype.nexus.transaction.TransactionalWrapper.proceedWithTransaction(TransactionalWrapper.java:57)
	at org.sonatype.nexus.transaction.TransactionInterceptor.proceedWithTransaction(TransactionInterceptor.java:66)
	at org.sonatype.nexus.transaction.TransactionInterceptor.invoke(TransactionInterceptor.java:55)
	at org.sonatype.nexus.plugins.apk.internal.ApkProxyFacetImpl.putIndex(ApkProxyFacetImpl.java:141)
	at org.sonatype.nexus.plugins.apk.internal.ApkProxyFacetImpl.store(ApkProxyFacetImpl.java:97)
	at org.sonatype.nexus.repository.proxy.ProxyFacetSupport.doGet(ProxyFacetSupport.java:285)
	at org.sonatype.nexus.repository.proxy.ProxyFacetSupport.lambda$1(ProxyFacetSupport.java:259)
	at org.sonatype.nexus.common.io.CooperatingFuture.performCall(CooperatingFuture.java:122)
	at org.sonatype.nexus.common.io.CooperatingFuture.call(CooperatingFuture.java:64)
	at org.sonatype.nexus.common.io.ScopedCooperationFactorySupport$ScopedCooperation.cooperate(ScopedCooperationFactorySupport.java:99)
	at org.sonatype.nexus.repository.proxy.ProxyFacetSupport.get(ProxyFacetSupport.java:250)
	at org.sonatype.nexus.repository.proxy.ProxyFacetSupport.get(ProxyFacetSupport.java:239)
	at org.sonatype.nexus.repository.proxy.ProxyHandler.handle(ProxyHandler.java:52)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.storage.LastDownloadedHandler.handle(LastDownloadedHandler.java:59)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.storage.UnitOfWorkHandler.handle(UnitOfWorkHandler.java:39)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.view.handlers.ConditionalRequestHandler.handle(ConditionalRequestHandler.java:72)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.view.handlers.ContentHeadersHandler.handle(ContentHeadersHandler.java:46)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.http.PartialFetchHandler.handle(PartialFetchHandler.java:59)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.cache.NegativeCacheHandler.handle(NegativeCacheHandler.java:56)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at com.sonatype.nexus.clm.internal.orient.FirewallContributedHandler.handle(FirewallContributedHandler.java:104)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.view.handlers.HandlerContributor.handle(HandlerContributor.java:67)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.view.handlers.ExceptionHandler.handle(ExceptionHandler.java:42)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.security.SecurityHandler.handle(SecurityHandler.java:51)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at com.sonatype.analytics.internal.handler.AnalyticsMeteringHandler.handle(AnalyticsMeteringHandler.java:69)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.view.handlers.TimingHandler.handle(TimingHandler.java:58)
	at org.sonatype.nexus.repository.view.Context.proceed(Context.java:88)
	at org.sonatype.nexus.repository.view.Context.start(Context.java:179)
	at org.sonatype.nexus.repository.view.Router.dispatch(Router.java:65)
	at org.sonatype.nexus.repository.view.ConfigurableViewFacet.dispatch(ConfigurableViewFacet.java:52)
	at org.sonatype.nexus.repository.view.ConfigurableViewFacet.dispatch(ConfigurableViewFacet.java:43)
	at org.sonatype.nexus.repository.httpbridge.internal.ViewServlet.dispatchAndSend(ViewServlet.java:213)
	at org.sonatype.nexus.repository.httpbridge.internal.ViewServlet.doService(ViewServlet.java:175)
	at org.sonatype.nexus.repository.httpbridge.internal.ViewServlet.service(ViewServlet.java:127)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at com.google.inject.servlet.ServletDefinition.doServiceImpl(ServletDefinition.java:290)
	at com.google.inject.servlet.ServletDefinition.doService(ServletDefinition.java:280)
	at com.google.inject.servlet.ServletDefinition.service(ServletDefinition.java:184)
	at com.google.inject.servlet.DynamicServletPipeline.service(DynamicServletPipeline.java:71)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:112)
	at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter(ProxiedFilterChain.java:61)
	at org.apache.shiro.web.servlet.AdviceFilter.executeChain(AdviceFilter.java:108)
	at org.apache.shiro.web.servlet.AdviceFilter.doFilterInternal(AdviceFilter.java:137)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:125)
	at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter(ProxiedFilterChain.java:66)
	at org.apache.shiro.web.servlet.AdviceFilter.executeChain(AdviceFilter.java:108)
	at org.apache.shiro.web.servlet.AdviceFilter.doFilterInternal(AdviceFilter.java:137)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:125)
	at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter(ProxiedFilterChain.java:66)
	at org.apache.shiro.web.servlet.AdviceFilter.executeChain(AdviceFilter.java:108)
	at org.apache.shiro.web.servlet.AdviceFilter.doFilterInternal(AdviceFilter.java:137)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:125)
	at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter(ProxiedFilterChain.java:66)
	at org.apache.shiro.web.servlet.AdviceFilter.executeChain(AdviceFilter.java:108)
	at org.apache.shiro.web.servlet.AdviceFilter.doFilterInternal(AdviceFilter.java:137)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:125)
	at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter(ProxiedFilterChain.java:66)
	at org.apache.shiro.web.servlet.AbstractShiroFilter.executeChain(AbstractShiroFilter.java:450)
	at org.sonatype.nexus.security.SecurityFilter.executeChain(SecurityFilter.java:96)
	at org.apache.shiro.web.servlet.AbstractShiroFilter$1.call(AbstractShiroFilter.java:365)
	at org.apache.shiro.subject.support.SubjectCallable.doCall(SubjectCallable.java:90)
	at org.apache.shiro.subject.support.SubjectCallable.call(SubjectCallable.java:83)
	at org.apache.shiro.subject.support.DelegatingSubject.execute(DelegatingSubject.java:387)
	at org.apache.shiro.web.servlet.AbstractShiroFilter.doFilterInternal(AbstractShiroFilter.java:362)
	at org.sonatype.nexus.security.SecurityFilter.doFilterInternal(SecurityFilter.java:112)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:125)
	at org.sonatype.nexus.repository.httpbridge.internal.ExhaustRequestFilter.doFilter(ExhaustRequestFilter.java:80)
	at com.sonatype.nexus.licensing.internal.LicensingRedirectFilter.doFilter(LicensingRedirectFilter.java:116)
	at com.codahale.metrics.servlet.AbstractInstrumentedFilter.doFilter(AbstractInstrumentedFilter.java:112)
	at org.sonatype.nexus.internal.web.ErrorPageFilter.doFilter(ErrorPageFilter.java:79)
	at org.sonatype.nexus.internal.web.EnvironmentFilter.doFilter(EnvironmentFilter.java:101)
	at org.sonatype.nexus.internal.web.HeaderPatternFilter.doFilter(HeaderPatternFilter.java:98)
	at com.google.inject.servlet.DynamicFilterPipeline.dispatch(DynamicFilterPipeline.java:104)
	at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:133)
	at org.sonatype.nexus.bootstrap.osgi.DelegatingFilter.doFilter(DelegatingFilter.java:73)
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:201)
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:548)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:602)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1435)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1350)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at com.codahale.metrics.jetty9.InstrumentedHandler.handle(InstrumentedHandler.java:239)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:516)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:383)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:882)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1036)
	at java.lang.Thread.run(Thread.java:748)
```

Indeed, ```org.sonatype.nexus.repository.storage.StorageTx``` class use ```InputStreamSupplier``` instead of ```Supplier<InputStream>``` in the ```setBlob``` method.

After switch classes in sources, everything works fine again. 